### PR TITLE
Fixes #12 - Remove the default driver

### DIFF
--- a/pytest_selenium/pytest_selenium.py
+++ b/pytest_selenium/pytest_selenium.py
@@ -8,6 +8,7 @@ import pytest
 import requests
 
 import cloud
+from driver import SUPPORTED_DRIVERS
 
 REQUESTS_TIMEOUT = 10
 
@@ -189,9 +190,10 @@ def pytest_addoption(parser):
     group._addoption('--driver',
                      action='store',
                      dest='driver',
-                     default=os.environ.get('SELENIUM_DRIVER', 'Remote'),
                      metavar='str',
-                     help='webdriver implementation. (default: %default)')
+                     help='webdriver implementation. '
+                          'Valid values are: %s.' %
+                          ', '.join(SUPPORTED_DRIVERS))
     group._addoption('--capability',
                      action='append',
                      dest='capabilities',

--- a/testing/test_driver.py
+++ b/testing/test_driver.py
@@ -28,11 +28,9 @@ def failure_with_output(testdir, *args, **kwargs):
 
 @pytest.fixture
 def failure(testdir, testfile, webserver_base_url):
-    return partial(failure_with_output, testdir, testfile, webserver_base_url,
-                   '--driver=Remote')
+    return partial(failure_with_output, testdir, testfile, webserver_base_url)
 
 
-def test_missing_browser_name(failure):
+def test_missing_driver(failure):
     out = failure()
-    assert out == ('UsageError: The \'browserName\' capability must be '
-                   'specified when using the remote driver.')
+    assert 'UsageError: --driver must be specified.' in out


### PR DESCRIPTION
I'm not sure if we wanted to try to introspect the `driver.py` file to determine the valid values of `--driver`, but I figured not. I also realize that the new test I added doesn't really belong in `test_remote.py` but I didn't see anywhere else to put it. I suppose we could create a new test file for tests that are not specific to a driver.

@davehunt / @justinpotts r?