### PR TITLE
Reintroduce support for specifying the path to the driver executable

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -110,33 +110,46 @@ There are therefore additional command line options for each of these. Check
 Chrome
 ------
 
-To use Chrome as the driver, you need to have ChromeDriver installed and
-available in your PATH. You can download it
-`here <https://sites.google.com/a/chromium.org/chromedriver/downloads>`_.
-
-To run your automated tests, specify ``Chrome`` as your driver:
+To use Chrome, you will need to
+`download ChromeDriver <https://sites.google.com/a/chromium.org/chromedriver/downloads>`_.
+and specify ``Chrome`` for the ``--driver`` command line option. If the driver
+executable is not available on your path, you can use the ``--driver-path``
+option to indicate where it can be found:
 
 .. code-block:: bash
 
-  $ py.test --driver Chrome
+  $ py.test --driver Chrome --driver-path /path/to/chromedriver
 
-For more information relating to ChromeDriver, you may read its documentation
-`here <https://sites.google.com/a/chromium.org/chromedriver/>`_.
+See the `ChromeDriver documentation <https://sites.google.com/a/chromium.org/chromedriver/>`_
+for more information.
+
+Internet Explorer
+-----------------
+
+To use Internet Explorer, you will need to download and configure the
+`Internet Explorer Driver <https://github.com/SeleniumHQ/selenium/wiki/InternetExplorerDriver>`_
+and specify ``IE`` for the ``--driver`` command line option. If the driver
+executable is not available on your path, you can use the ``--driver-path``
+option to indicate where it can be found:
+
+.. code-block:: batch
+
+  > py.test --driver IE --driver-path \path\to\IEDriverServer.exe
 
 PhantomJS
 ---------
 
-To use PhantomJS as the driver, you need to have it installed and available in
-your PATH. You can download it `here <http://phantomjs.org/download.html>`_.
-
-To run your automated tests, specify ``PhantomJS`` as your driver:
+To use PhantomJS, you will need `download it <http://phantomjs.org/download.html>`_.
+and specify ``PhantomJS`` for the ``--driver`` command line option. If
+the driver executable is not available on your path, you can use the
+``--driver-path`` option to indicate where it can be found:
 
 .. code-block:: bash
 
-  $ py.test --driver PhantomJS
+  $ py.test --driver PhantomJS --driver-path /path/to/phantomjs
 
-For more information relating to PhantomJS, you may read its documentation
-`here <http://phantomjs.org/quick-start.html>`_.
+See the `PhantomJS documentation <http://phantomjs.org/quick-start.html>`_ for
+more information.
 
 Selenium Server/Grid
 --------------------

--- a/pytest_selenium/driver.py
+++ b/pytest_selenium/driver.py
@@ -5,10 +5,11 @@
 import copy
 
 import pytest
+from selenium import webdriver
+from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 from selenium.webdriver.support.event_firing_webdriver import \
     EventFiringWebDriver
-from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
-from selenium import webdriver
 
 
 def start_driver(item, capabilities):
@@ -38,31 +39,43 @@ def browserstack_driver(item, capabilities):
 
 def chrome_driver(item, capabilities):
     """Return a WebDriver using a Chrome instance"""
-    return webdriver.Chrome(desired_capabilities=capabilities)
+    options = item.config.option
+    kwargs = {'desired_capabilities': capabilities}
+    if options.driver_path is not None:
+        kwargs['executable_path'] = options.driver_path
+    return webdriver.Chrome(**kwargs)
 
 
 def firefox_driver(item, capabilities):
     """Return a WebDriver using a Firefox instance"""
     options = item.config.option
-    binary = None
-    if options.firefox_path:
+    kwargs = {'capabilities': capabilities or None}
+    if options.driver_path is not None:
+        kwargs['executable_path'] = options.driver_path
+    if options.firefox_path is not None:
         # get firefox binary from options until there's capabilities support
-        binary = FirefoxBinary(options.firefox_path)
-    profile = _create_firefox_profile(options)
-    return webdriver.Firefox(
-        firefox_binary=binary,
-        firefox_profile=profile,
-        capabilities=capabilities or None)
+        kwargs['firefox_binary'] = FirefoxBinary(options.firefox_path)
+    kwargs['firefox_profile'] = _create_firefox_profile(options)
+    return webdriver.Firefox(**kwargs)
 
 
 def ie_driver(item, capabilities):
     """Return a WebDriver using an Internet Explorer instance"""
-    return webdriver.Ie(capabilities=capabilities)
+    options = item.config.option
+    kwargs = {'capabilities': capabilities or None}
+    if options.driver_path is not None:
+        kwargs['executable_path'] = options.driver_path
+    return webdriver.Ie(**kwargs)
 
 
 def phantomjs_driver(item, capabilities):
     """Return a WebDriver using a PhantomJS instance"""
-    return webdriver.PhantomJS(desired_capabilities=capabilities)
+    options = item.config.option
+    _capabilities = capabilities or DesiredCapabilities.PHANTOMJS
+    kwargs = {'desired_capabilities': _capabilities}
+    if options.driver_path is not None:
+        kwargs['executable_path'] = options.driver_path
+    return webdriver.PhantomJS(**kwargs)
 
 
 def remote_driver(item, capabilities):

--- a/pytest_selenium/pytest_selenium.py
+++ b/pytest_selenium/pytest_selenium.py
@@ -182,6 +182,9 @@ def pytest_addoption(parser):
                      choices=SUPPORTED_DRIVERS,
                      help='webdriver implementation.',
                      metavar='str')
+    group._addoption('--driver-path',
+                     metavar='path',
+                     help='path to the driver executable.')
     group._addoption('--capability',
                      action='append',
                      default=[],


### PR DESCRIPTION
I couldn't think of a smarter way to allow users to specify the paths to driver executables. Pinging @bobsilverberg for review.