### PR TITLE
Remove verify autouse fixture

### DIFF
--- a/pytest_selenium/pytest_selenium.py
+++ b/pytest_selenium/pytest_selenium.py
@@ -41,26 +41,24 @@ def _environment(request, base_url, capabilities):
 
 @pytest.fixture(scope='session')
 def base_url(request):
-    """Return base URL from command line options"""
+    """Return a verified base URL"""
     config = request.config
-    url = config.option.base_url or config.getini('selenium_base_url')
-    if not url:
-        raise pytest.UsageError('--base-url must be specified.')
-    return url
-
-
-@pytest.fixture(scope='session', autouse=True)
-def _verify_base_url(request, base_url):
-    """Verify that the base URL is responding with an acceptable status code"""
+    base_url = config.option.base_url or config.getini('selenium_base_url')
     if base_url:
-        response = requests.get(base_url, timeout=REQUESTS_TIMEOUT)
-        ok_codes = (200, 401)
-        if response.status_code not in ok_codes:
-            raise pytest.UsageError(
-                'Base URL did not respond with one of the following status '
-                'codes: {0}.\nURL: {1},\nResponse status code: {2.status_code}'
-                '\nResponse headers: {2.headers}'.format(
-                    ', '.join(map(str, ok_codes)), base_url, response))
+        verify_url(base_url)
+        return base_url
+    raise pytest.UsageError('--base-url must be specified.')
+
+
+def verify_url(url):
+    response = requests.get(url, timeout=REQUESTS_TIMEOUT)
+    ok_codes = (200, 401)
+    if response.status_code not in ok_codes:
+        raise pytest.UsageError(
+            'Base URL did not respond with one of the following status '
+            'codes: {0}.\nURL: {1},\nResponse status code: {2.status_code}'
+            '\nResponse headers: {2.headers}'.format(
+                ', '.join(map(str, ok_codes)), url, response))
 
 
 @pytest.fixture(scope='session')

--- a/testing/test_base_url.py
+++ b/testing/test_base_url.py
@@ -56,13 +56,10 @@ def test_failing_base_url(testdir, webserver):
     base_url = 'http://localhost:{0}/{1}/'.format(webserver.port, status_code)
     testdir.makepyfile("""
         import pytest
-        @pytest.fixture(scope='session')
-        def base_url():
-            return '{0}'
         @pytest.mark.nondestructive
-        def test_pass(_verify_base_url): pass
+        def test_pass(): pass
     """.format(base_url))
-    result = testdir.runpytest()
+    result = testdir.runpytest('--base-url', base_url)
     assert result.ret != 0
     # tracestyle is native by default for hook failures
     result.stdout.fnmatch_lines([


### PR DESCRIPTION
@birdsarah would you mind taking a look at this? It moves the verifying of the base URL into the default base URL fixture. This means that by overriding the base_url fixture, there will be a responsibility on the fixture author to reimplement the verification if they choose.