### PR TITLE
Avoid checking if the base URL is senstive for every test

### DIFF
--- a/pytest_selenium/pytest_selenium.py
+++ b/pytest_selenium/pytest_selenium.py
@@ -73,7 +73,7 @@ def capabilities(request, variables):
 
 
 @pytest.fixture
-def selenium(request, _sensitive_skipping, capabilities):
+def selenium(request, skip_sensitive, capabilities):
     """Returns a WebDriver instance based on options and capabilities"""
     from .driver import start_driver
     driver = start_driver(request.node, capabilities)

--- a/testing/test_destructive.py
+++ b/testing/test_destructive.py
@@ -37,11 +37,11 @@ def test_run_destructive_and_non_destructive_when_forced(testdir):
 
 
 def test_skip_destructive_when_forced_and_sensitive(testdir):
-    file_test = testdir.makepyfile('def test_pass(_sensitive_skipping): pass')
+    file_test = testdir.makepyfile('def test_pass(skip_sensitive): pass')
     testdir.quick_qa('--destructive', file_test, skipped=1)
 
 
 def test_run_destructive_when_forced_and_not_sensitive(testdir):
-    file_test = testdir.makepyfile('def test_pass(_sensitive_skipping): pass')
-    testdir.quick_qa('--destructive', '--sensitive-url', 'foo', file_test,
+    file_test = testdir.makepyfile('def test_pass(skip_sensitive): pass')
+    testdir.quick_qa('--destructive', '--sensitive-url', None, file_test,
                      passed=1)


### PR DESCRIPTION
I realised we were checking the history of the reponses for every test, which is excessive. This addresses that and also cleans up the fixture names. If you want to disable sensitive URL checking you can either set the `--sensitive-url` option to `None` or override the `sensitive_url` fixture and return `False`.