### PR TITLE
Add a way to control when HTML report debug is gathered, and capture logs unless excluded

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -356,3 +356,26 @@ the implicit timeout or window size, you can override the ``selenium`` fixture:
       selenium.implicitly_wait(10)
       selenium.maximize_window()
       return selenium
+
+HTML Report
+***********
+
+A custom HTML report is generated when the ``--html`` command line option is
+given. By default this will include additional debug information for failures
+such as the URL, HTML, logs, and a screenshot at the point the test finished.
+
+Capturing Debug
+---------------
+
+To change when debug is captured you can either add a ``selenium_capture_debug``
+item to the ``[pytest]`` section of a ``setup.cfg`` file, or set the
+``SELENIUM_CAPTURE_DEBUG`` environment variable. Valid options are: ``never``,
+``failure`` (the default), and ``always``. Note that always capturing debug will
+dratamtically increase the size of the HTML report.
+
+Excluding Logs
+--------------
+
+Log files can contain sensitive information. To exclude them from the report
+set the ``selenium_exclude_debug`` option or ``SELENIUM_EXCLUDE_DEBUG``
+environment variable to ``logs``.

--- a/pytest_selenium/pytest_selenium.py
+++ b/pytest_selenium/pytest_selenium.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from datetime import datetime
 import os
 
 import pytest
@@ -89,17 +90,19 @@ def pytest_runtest_makereport(__multicall__, item, call):
     extra = getattr(report, 'extra', [])
     if report.when == 'call':
         driver = getattr(item, '_driver', None)
+        xfail = hasattr(report, 'wasxfail')
+        failure = (report.skipped and xfail) or (report.failed and not xfail)
+        capture = item.config.getini('selenium_capture_debug').lower()
+        debug = capture == 'always' or (capture == 'failure' and failure)
+        exclude_debug = item.config.getini('selenium_exclude_debug')
         if driver is not None:
-            xfail = hasattr(report, 'wasxfail')
-            # only gather debug if test failed or xfailed
-            debug = (report.skipped and xfail) or (report.failed and not xfail)
             if debug:
                 url = driver.current_url
                 if url is not None:
-                    # add failing url to the console output
-                    extra_summary.append('Failing URL: {0}'.format(url))
+                    # add url to the console output
+                    extra_summary.append('URL: {0}'.format(url))
                     if pytest_html is not None:
-                        # add failing url to the html report
+                        # add url to the html report
                         extra.append(pytest_html.extras.url(url))
                 screenshot = driver.get_screenshot_as_base64()
                 if screenshot is not None and pytest_html is not None:
@@ -110,6 +113,12 @@ def pytest_runtest_makereport(__multicall__, item, call):
                 if html is not None and pytest_html is not None:
                     # add page source to the html report
                     extra.append(pytest_html.extras.text(html, 'HTML'))
+                if 'logs' not in exclude_debug:
+                    for log_type in driver.log_types:
+                        log = driver.get_log(log_type)
+                        if log and pytest_html is not None:
+                            extra.append(pytest_html.extras.text(
+                                format_log(log), '%s Log' % log_type.title()))
             driver_name = item.config.option.driver
             if hasattr(cloud, driver_name.lower()) and driver.session_id:
                 provider = getattr(cloud, driver_name.lower()).Provider()
@@ -133,8 +142,26 @@ def pytest_runtest_makereport(__multicall__, item, call):
     return report
 
 
+def format_log(log):
+    timestamp_format = '%Y-%m-%d %H:%M:%S.%f'
+    entries = ['{0} {1[level]} - {1[message]}'.format(
+        datetime.utcfromtimestamp(entry['timestamp'] / 1000.0).strftime(
+            timestamp_format), entry).rstrip() for entry in log]
+    return '\n'.join(entries)
+
+
 def pytest_addoption(parser):
-    parser.addini('selenium_base_url', 'base url for selenium')
+    parser.addini('selenium_base_url',
+                  help='base url for selenium')
+
+    _capture_choices = ('never', 'failure', 'always')
+    parser.addini('selenium_capture_debug',
+                  help='when debug is captured {0}'.format(_capture_choices),
+                  default=os.getenv('SELENIUM_CAPTURE_DEBUG', 'failure'))
+    parser.addini('selenium_exclude_debug',
+                  help='debug to exclude from capture',
+                  type='args',
+                  default=os.getenv('SELENIUM_EXCLUDE_DEBUG'))
 
     # browserstack configuration
     parser.addini('browserstack_username',


### PR DESCRIPTION
Also added a section to the documentation on the HTML report.