### PR TITLE
Strip trailing slashes from base URL

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+**1.0b3**
+
+* Strip trailing slashes from base URL.
+
 **1.0b2 (2015-10-06)**
 
 * Added support for non ASCII characters in log files. (#33)

--- a/pytest_selenium/pytest_selenium.py
+++ b/pytest_selenium/pytest_selenium.py
@@ -41,6 +41,7 @@ def base_url(request):
     """Return a base URL"""
     config = request.config
     base_url = config.option.base_url or config.getini('base_url')
+    base_url = base_url.rstrip('/')
     if base_url:
         config._environment.append(('Base URL', base_url))
         return base_url

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -18,7 +18,7 @@ def base_url(webserver):
 
 @pytest.fixture
 def webserver_base_url(webserver):
-    return '--base-url={0}'.format(base_url(webserver))
+    return '--base-url={0}/'.format(base_url(webserver))
 
 
 @pytest.fixture(autouse=True)

--- a/testing/test_base_url.py
+++ b/testing/test_base_url.py
@@ -34,7 +34,7 @@ def test_config(testdir, webserver):
     base_url = 'http://localhost:{0}/foo'.format(webserver.port)
     testdir.makefile('.ini', pytest="""
         [pytest]
-        base_url={0}
+        base_url={0}/
     """.format(base_url))
     file_test = testdir.makepyfile("""
         import pytest
@@ -42,4 +42,6 @@ def test_config(testdir, webserver):
         def test_config(base_url):
             assert base_url == '{0}'
     """.format(base_url))
-    testdir.inline_run(file_test)
+    reprec = testdir.inline_run(file_test)
+    passed, skipped, failed = reprec.listoutcomes()
+    assert len(passed) == 1

--- a/testing/test_verify_base_url.py
+++ b/testing/test_verify_base_url.py
@@ -25,14 +25,14 @@ def failure_with_output(testdir, *args, **kwargs):
 
 
 def test_ignore_bad_url(testdir, testfile, webserver):
-    base_url = 'http://localhost:{0}/500/'.format(webserver.port)
+    base_url = 'http://localhost:{0}/500'.format(webserver.port)
     testdir.quick_qa('--base-url', base_url, testfile, passed=1)
 
 
 def test_enable_verify_via_cli(testdir, testfile, webserver, monkeypatch):
     monkeypatch.setenv('VERIFY_BASE_URL', False)
     status_code = 500
-    base_url = 'http://localhost:{0}/{1}/'.format(webserver.port, status_code)
+    base_url = 'http://localhost:{0}/{1}'.format(webserver.port, status_code)
     out = failure_with_output(testdir, testfile, '--base-url', base_url,
                               '--verify-base-url')
     assert 'UsageError: Base URL failed verification!' in out
@@ -44,7 +44,7 @@ def test_enable_verify_via_cli(testdir, testfile, webserver, monkeypatch):
 def test_enable_verify_via_env(testdir, testfile, webserver, monkeypatch):
     monkeypatch.setenv('VERIFY_BASE_URL', True)
     status_code = 500
-    base_url = 'http://localhost:{0}/{1}/'.format(webserver.port, status_code)
+    base_url = 'http://localhost:{0}/{1}'.format(webserver.port, status_code)
     out = failure_with_output(testdir, testfile, '--base-url', base_url)
     assert 'UsageError: Base URL failed verification!' in out
     assert 'URL: {0}'.format(base_url) in out
@@ -54,5 +54,5 @@ def test_enable_verify_via_env(testdir, testfile, webserver, monkeypatch):
 
 def test_disable_verify_via_env(testdir, testfile, webserver, monkeypatch):
     monkeypatch.setenv('VERIFY_BASE_URL', False)
-    base_url = 'http://localhost:{0}/500/'.format(webserver.port)
+    base_url = 'http://localhost:{0}/500'.format(webserver.port)
     testdir.quick_qa('--base-url', base_url, testfile, passed=1)

--- a/testing/webserver.py
+++ b/testing/webserver.py
@@ -37,8 +37,8 @@ class HtmlOnlyHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         """GET method handler."""
 
-        path_parts = self.path.split('/')
-        response_code = len(path_parts) == 3 and int(path_parts[1]) or 200
+        path_parts = filter(None, self.path.split('/'))
+        response_code = path_parts and int(path_parts[0]) or 200
         self.send_response(response_code)
         self.send_header('Content-type', 'text/html; charset="utf-8"')
         self.end_headers()


### PR DESCRIPTION
I'd appreciate your thoughts on this change @bobsilverberg. My thinking was that we could strip trailing forward slashes from the base URL so that there's a consistent expectation of how to construct URLs from it. I'm conflicted though as we're manipulating something explicitly set by the user, which could be confusing and in some circumstances frustrating. I think I've talked myself out of landing this, but would like to hear your thoughts.