### PR TITLE
Consistently stash the base URL in the configuration options

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -118,6 +118,23 @@ responding before proceeding with the test suite. To enable this, specify the
 ``--verify-base-url`` command line option or set the ``VERIFY_BASE_URL``
 environment variable to ``TRUE``.
 
+Skipping Base URLs
+------------------
+
+You can `skip tests <http://pytest.org/latest/skipping.html>`_ based on the
+value of the base URL so long as it is provided either by the command line or
+in a configuration file:
+
+.. code-block:: python
+
+  import pytest
+
+  @pytest.mark.skipif('dev' in pytest.config.getoption('base_url'), reason='Search not available on dev')
+  def test_search(base_url, selenium):
+      selenium.get('{0}/search'.format(base_url))
+
+Unfortunately if the URL is provided by a fixture, there is no way to know this
+value at test collection.
 
 Sensitive Environments
 **********************

--- a/pytest_selenium/pytest_selenium.py
+++ b/pytest_selenium/pytest_selenium.py
@@ -40,8 +40,8 @@ def _environment(request, capabilities):
 def base_url(request):
     """Return a base URL"""
     config = request.config
-    base_url = config.option.base_url or config.getini('base_url')
-    if base_url:
+    base_url = config.getoption('base_url')
+    if base_url is not None:
         config._environment.append(('Base URL', base_url))
         return base_url
 
@@ -81,6 +81,9 @@ def selenium(request, capabilities):
 def pytest_configure(config):
     if hasattr(config, 'slaveinput'):
         return  # xdist slave
+    base_url = config.getoption('base_url') or config.getini('base_url')
+    if base_url is not None:
+        config.option.base_url = base_url
     config.addinivalue_line(
         'markers', 'capabilities(kwargs): add or change existing '
         'capabilities. specify capabilities as keyword arguments, for example '


### PR DESCRIPTION
@bobsilverberg could you review this? It will mean that we only need to check `config.getoption` for the base URL even if it's specified in an INI file.

See also: https://github.com/mozilla/mcom-tests/blob/e0618d117000f338c37ebabd96de52469a4ca39b/tests/test_l10n_download_links.py#L13 and https://github.com/mozilla/Socorro-Tests/pull/341/files#r45722474

/cc @m8ttyB