### PR TITLE
Report warnings when gathering debug fails rather than raising exceptions

### DIFF
--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -37,6 +37,12 @@ def testdir(request, webserver_base_url):
             return selenium.find_element_by_tag_name('h1').text
         """)
 
+    def runpytestqa(*args, **kwargs):
+        return testdir.runpytest(webserver_base_url, '--driver', 'Firefox',
+                                 *args, **kwargs)
+
+    testdir.runpytestqa = runpytestqa
+
     def inline_runqa(*args, **kwargs):
         return testdir.inline_run(webserver_base_url, '--driver', 'Firefox',
                                   *args, **kwargs)

--- a/testing/test_driver.py
+++ b/testing/test_driver.py
@@ -34,3 +34,21 @@ def failure(testdir, testfile, webserver_base_url):
 def test_missing_driver(failure):
     out = failure()
     assert 'UsageError: --driver must be specified' in out
+
+
+def test_driver_quit(testdir):
+    testdir.makepyfile("""
+        import pytest
+        @pytest.mark.nondestructive
+        def test_driver_quit(selenium):
+            selenium.quit()
+    """)
+    result = testdir.runpytestqa()
+    result.stdout.fnmatch_lines_random([
+        'WARNING: Failed to gather URL: *',
+        'WARNING: Failed to gather screenshot: *',
+        'WARNING: Failed to gather HTML: *',
+        'WARNING: Failed to gather log types: *'])
+    outcomes = result.parseoutcomes()
+    assert outcomes.get('passed') == 1
+    assert outcomes.get('error') == 1


### PR DESCRIPTION
Also I don't know why, but we never previously attempted to gather debug on setup/teardown, which could be useful (especially on setup when fixtures are involved). Would you mind having a look over this @bobsilverberg?