### PR TITLE
Avoid deprecation warnings on pytest 2.8 and drop support for pytest 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,8 @@ env:
   global:
     - DISPLAY=':99.0'
   matrix:
-    - PYTEST=2.6.4
     - PYTEST=2.7.3
-    - PYTEST=2.8.2
+    - PYTEST=2.8.3
 matrix:
   fast_finish: true
   allow_failures:

--- a/pytest_selenium/pytest_selenium.py
+++ b/pytest_selenium/pytest_selenium.py
@@ -88,10 +88,12 @@ def pytest_configure(config):
         'capabilities(foo=''bar'')')
 
 
-def pytest_runtest_makereport(__multicall__, item, call):
+@pytest.mark.hookwrapper
+def pytest_runtest_makereport(item, call):
+    outcome = yield
     pytest_html = item.config.pluginmanager.getplugin('html')
     extra_summary = []
-    report = __multicall__.execute()
+    report = outcome.get_result()
     extra = getattr(report, 'extra', [])
     if report.when == 'call':
         driver = getattr(item, '_driver', None)
@@ -156,7 +158,6 @@ def pytest_runtest_makereport(__multicall__, item, call):
                 provider.update_status(item.config, driver.session_id, passed)
         report.sections.append(('pytest-selenium', '\n'.join(extra_summary)))
         report.extra = extra
-    return report
 
 
 def format_log(log):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name='pytest-selenium',
       url='https://github.com/davehunt/pytest-selenium',
       packages=['pytest_selenium', 'pytest_selenium.cloud'],
       install_requires=[
-          'pytest>=2.6.4',
+          'pytest>=2.7.3',
           'pytest-html>=1.7',
           'pytest-variables',
           'selenium>=2.26.0',

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,10 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py34, pypy, pypy3
+envlist = py{26,27,33,34,py,py3}-pytest{27,28}
 
 [testenv]
 commands = py.test -m 'not (chrome or phantomjs)' {posargs}
-deps = pytest
+deps =
+    pytest27: pytest==2.7.*
+    pytest28: pytest==2.8.*


### PR DESCRIPTION
This gets rid of the annoying pytest warning. Feel free to look over it @bobsilverberg but if Travis is happy I'll probably just merge.