### PR TITLE
Set a timeout for all requests calls and warn if any cloud provider calls fail

### DIFF
--- a/pytest_selenium/cloud/browserstack.py
+++ b/pytest_selenium/cloud/browserstack.py
@@ -40,7 +40,8 @@ class Provider(CloudProvider):
     def url(self, config, session):
         response = requests.get(self._session_url.format(id=session),
                                 auth=(self._username(config),
-                                      self._access_key(config)))
+                                      self._access_key(config)),
+                                timeout=10)
         return response.json()['automation_session']['browser_url']
 
     def additional_html(self, session):
@@ -51,4 +52,5 @@ class Provider(CloudProvider):
         requests.put(self._session_url.format(id=session),
                      headers={'Content-Type': 'application/json'},
                      params=status,
-                     auth=(self._username(config), self._access_key(config)))
+                     auth=(self._username(config), self._access_key(config)),
+                     timeout=10)

--- a/pytest_selenium/cloud/saucelabs.py
+++ b/pytest_selenium/cloud/saucelabs.py
@@ -57,7 +57,8 @@ class Provider(CloudProvider):
         status = {'passed': passed}
         requests.put('http://saucelabs.com/rest/v1/{0}/jobs/{1}'.format(
             username, session),
-            data=json.dumps(status), auth=(username, api_key))
+            data=json.dumps(status), auth=(username, api_key),
+            timeout=10)
 
     def _video_html(self, session):
         flash_vars = 'config={{\

--- a/pytest_selenium/cloud/testingbot.py
+++ b/pytest_selenium/cloud/testingbot.py
@@ -53,7 +53,8 @@ class Provider(CloudProvider):
     def update_status(self, config, session, passed):
         requests.put('https://api.testingbot.com/v1/tests/{0}'.format(session),
                      data={'test[success]': '1' if passed else '0'},
-                     auth=(self._key(config), self._secret(config)))
+                     auth=(self._key(config), self._secret(config)),
+                     timeout=10)
 
     def _video_html(self, session):
         flash_vars = 'config={{\

--- a/pytest_selenium/safety.py
+++ b/pytest_selenium/safety.py
@@ -47,7 +47,7 @@ def sensitive_url(request, base_url):
 
     urls = [base_url]
     try:
-        response = requests.get(base_url)
+        response = requests.get(base_url, timeout=10)
         urls.append(response.url)
         urls.extend([history.url for history in response.history])
     except requests.exceptions.RequestException:


### PR DESCRIPTION
@bobsilverberg mind having a look over these changes? I noticed that if our tests fail due to the remote session ending we can timeout waiting to update the test status. This just makes sure we always set a reasonable timeout for requests, and also makes sure that any issues communicating with a cloud provider do not cause exceptions, but are logged as warnings.